### PR TITLE
Removing the master and slave vocabulary

### DIFF
--- a/EFA/efa_files/operational_cfsv2_st.py
+++ b/EFA/efa_files/operational_cfsv2_st.py
@@ -86,7 +86,7 @@ def get_cfsv2_ensemble(ndays, start, end, vrbls=['Z500'],
 # and the timedelta part and indent after the for loop.
 #    for i in range(4*ndays):
     idate = start #- timedelta(hours=i*6)
-    # List the four members at this time and append to master list
+    # List the four members at this time and append to main list
     datestr = idate.strftime('%Y%m%d%H')
     command = 'ls -1a {}/pgbf_{}*.nc'.format(indir,datestr)
     print(command)

--- a/EFA/efa_files/operational_cfsv2_st_analysis.py
+++ b/EFA/efa_files/operational_cfsv2_st_analysis.py
@@ -59,7 +59,7 @@ def get_cfsv2_ensemble(ndays, start, end, vrbls=['Z500'],
 # and the timedelta part and indent after the for loop.
 #    for i in range(4*ndays):
     idate = start #- timedelta(hours=i*6)
-    # List the four members at this time and append to master list
+    # List the four members at this time and append to main list
     datestr = idate.strftime('%Y%m%d%H')
     command = 'ls -1a {}/*.nc'.format(indir,datestr)
     print(command)

--- a/efa_xray/state/ensemble.py
+++ b/efa_xray/state/ensemble.py
@@ -59,8 +59,8 @@ class EnsembleState(xarray.Dataset):
     def split_state(self,nChunks):
         """ Function to split the state xarray object into nChunks number of
         smaller xarray objects for multiprocessing.  Returns a dictionary of state
-        chunks.  This dictionary may be re-fed into the master state using the
-        function "reintegrate_state" which will overwrite the master state xarray
+        chunks.  This dictionary may be re-fed into the main state using the
+        function "reintegrate_state" which will overwrite the main state xarray
         object with the separate parts """
         
         state_chunks = {}
@@ -82,7 +82,7 @@ class EnsembleState(xarray.Dataset):
         # Get the bounds
         bounds = self.chunk_bounds(num_chunks)
 
-        # Now reset the master state vector
+        # Now reset the main state vector
         for cnum, bnds in bounds.items():
             self.state[dict(location=slice(bnds[0],bnds[1]))] = state_chunks[cnum].state
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.